### PR TITLE
fix #552: Update direct links from Gilead-BioStats to Gilead-Public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # gsm.viz
-[gsm.viz](https://github.com/Gilead-BioStats/gsm.viz/) is a data visualization library built with
+[gsm.viz](https://github.com/Gilead-Public/gsm.viz/) is a data visualization library built with
 [Chart.js](https://www.chartjs.org/) that features charts adapted for
 [risk-based monitoring](https://www.fda.gov/media/121479/download) in clinical trials.
 
 ## Examples
-Production examples of `gsm.viz` modules are accessible [here](https://gilead-biostats.github.io/gsm.viz/)
-and development examples [here](https://gilead-biostats.github.io/gsm.viz/dev/).
+Production examples of `gsm.viz` modules are accessible [here](https://gilead-public.github.io/gsm.viz/)
+and development examples [here](https://gilead-public.github.io/gsm.viz/dev/).
 
 **Generics**
-- [bar chart](https://gilead-biostats.github.io/gsm.viz/bars/)
-- [bar chart builder](https://gilead-biostats.github.io/gsm.viz/bars/builder.html)
+- [bar chart](https://gilead-public.github.io/gsm.viz/bars/)
+- [bar chart builder](https://gilead-public.github.io/gsm.viz/bars/builder.html)
 
 **Metrics**
-- [bar chart](https://gilead-biostats.github.io/gsm.viz/barChart/)
-- [group overview — country](https://gilead-biostats.github.io/gsm.viz/groupOverview/country/)
-- [group overview — site](https://gilead-biostats.github.io/gsm.viz/groupOverview/site/)
-- [scatter plot](https://gilead-biostats.github.io/gsm.viz/scatterPlot/)
-- [sparkline](https://gilead-biostats.github.io/gsm.viz/sparkline/)
-- [time series](https://gilead-biostats.github.io/gsm.viz/timeSeriesContinuous/)
-- [time series (with CI)](https://gilead-biostats.github.io/gsm.viz/timeSeriesWithCI/)
+- [bar chart](https://gilead-public.github.io/gsm.viz/barChart/)
+- [group overview — country](https://gilead-public.github.io/gsm.viz/groupOverview/country/)
+- [group overview — site](https://gilead-public.github.io/gsm.viz/groupOverview/site/)
+- [scatter plot](https://gilead-public.github.io/gsm.viz/scatterPlot/)
+- [sparkline](https://gilead-public.github.io/gsm.viz/sparkline/)
+- [time series](https://gilead-public.github.io/gsm.viz/timeSeriesContinuous/)
+- [time series (with CI)](https://gilead-public.github.io/gsm.viz/timeSeriesWithCI/)
 
 ## Installation
 
 `gsm.viz` is hosted on GitHub and accessible with `npm`:
 
 ```
-npm install git+https://github.com/Gilead-BioStats/gsm.viz.git
+npm install git+https://github.com/Gilead-Public/gsm.viz.git
 ```
 
 ## Contributor Guidelines
@@ -35,7 +35,7 @@ npm install git+https://github.com/Gilead-BioStats/gsm.viz.git
 Clone `gsm.viz` with `git` and install its dependencies:
 
 ```
-git clone https://github.com/Gilead-BioStats/gsm.viz.git
+git clone https://github.com/Gilead-Public/gsm.viz.git
 cd gsm.viz
 npm install
 ```
@@ -67,7 +67,7 @@ git commit -a -m 'fix #123'
 git push -u origin fix-123
 ```
 
-On GitHub, open a [pull request](https://github.com/Gilead-BioStats/gsm.viz/pulls) with `fix-123` as
+On GitHub, open a [pull request](https://github.com/Gilead-Public/gsm.viz/pulls) with `fix-123` as
 the source and `dev` as the target.  The pull request requires a code review prior to merging.
 
 ## Update Example Data

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 [Chart.js](https://www.chartjs.org/) that features charts adapted for
 [risk-based monitoring](https://www.fda.gov/media/121479/download) in clinical trials.
 
-[![GitHub](https://img.shields.io/badge/GitHub-Gilead--BioStats%2Fgsm.viz-blue?logo=github)](https://github.com/Gilead-BioStats/gsm.viz)
+[![GitHub](https://img.shields.io/badge/GitHub-Gilead--BioStats%2Fgsm.viz-blue?logo=github)](https://github.com/Gilead-Public/gsm.viz)
 
 ---
 
@@ -42,7 +42,7 @@
 `gsm.viz` is hosted on GitHub and accessible with `npm`:
 
 ```bash
-npm install git+https://github.com/Gilead-BioStats/gsm.viz.git
+npm install git+https://github.com/Gilead-Public/gsm.viz.git
 ```
 
 ---
@@ -80,5 +80,5 @@ the sidebar for full parameter and config documentation.
 
 ## Contributing
 
-See the [repository README](https://github.com/Gilead-BioStats/gsm.viz#readme)
+See the [repository README](https://github.com/Gilead-Public/gsm.viz#readme)
 for contributor guidelines, development setup, and version-control conventions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 [Chart.js](https://www.chartjs.org/) that features charts adapted for
 [risk-based monitoring](https://www.fda.gov/media/121479/download) in clinical trials.
 
-[![GitHub](https://img.shields.io/badge/GitHub-Gilead--BioStats%2Fgsm.viz-blue?logo=github)](https://github.com/Gilead-Public/gsm.viz)
+[![GitHub](https://img.shields.io/badge/GitHub-Gilead--Public%2Fgsm.viz-blue?logo=github)](https://github.com/Gilead-Public/gsm.viz)
 
 ---
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,7 +38,7 @@
 
     <body>
         <nav>
-            <a href="https://github.com/Gilead-BioStats/gsm.viz">GitHub</a>
+            <a href="https://github.com/Gilead-Public/gsm.viz">GitHub</a>
         </nav>
 
         <div id="app">Loading…</div>
@@ -46,7 +46,7 @@
         <script>
             window.$docsify = {
                 name: 'gsm.viz',
-                repo: 'https://github.com/Gilead-BioStats/gsm.viz',
+                repo: 'https://github.com/Gilead-Public/gsm.viz',
                 loadSidebar: true,
                 subMaxLevel: 2,
                 search: {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Gilead-BioStats/gsm.viz.git"
+    "url": "git+https://github.com/Gilead-Public/gsm.viz.git"
   },
   "keywords": [
     "rbqm",
@@ -38,9 +38,9 @@
   "author": "Gilead Sciences",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Gilead-BioStats/gsm.viz/issues"
+    "url": "https://github.com/Gilead-Public/gsm.viz/issues"
   },
-  "homepage": "https://github.com/Gilead-BioStats/gsm.viz#readme",
+  "homepage": "https://github.com/Gilead-Public/gsm.viz#readme",
   "dependencies": {
     "@sgratzl/chartjs-chart-boxplot": "^3.10.0",
     "chart.js": "^3.9.1",


### PR DESCRIPTION
## Summary

Updates all direct org links in docs and config that point to the old `Gilead-BioStats` organization to use `Gilead-Public` instead.

## Changes

- **README.md**: Updated 10 GitHub Pages links and 3 github.com repo links
- **examples/README.md**: Updated org badge, `npm install` snippet, and contributing link
- **examples/index.html**: Updated nav anchor and docsify `repo` config
- **package.json**: Updated `repository.url`, `bugs.url`, and `homepage`

## Intentionally Unchanged

- `.github/ISSUE_TEMPLATE/`: `Gilead-BioStats/41` (gsm Roadmap project) still lives at Gilead-BioStats with no equivalent at Gilead-Public — left as-is to avoid breaking project board references
- `src/groupOverview/configure.js` + `src/groupOverview/defineColumns/defineRiskScoreTooltip.js`: `SiteRiskScoreURL` points to `gilead-biostats.github.io/gsm.kri` — the Gilead-Public equivalent returns 404; should be updated as a follow-on once gsm.kri migrates

## Resolves

- Resolves #552